### PR TITLE
docs: add Squarespace Domains -> Cloudflare Pages cutover guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,17 +56,97 @@ Node.js は v22 LTS 以降を推奨（リポジトリ直下の `.nvmrc` で v24 
 4. **Save and Deploy** で初回ビルドを実行
 5. 完了すると `*.pages.dev` のプレビュー URL が発行される
 
-カスタムドメイン設定は Phase 3 (`docs/domain-cutover`) で実施する。
+カスタムドメイン設定は下記「[ドメイン切替手順](#ドメイン切替手順squarespace-domains--cloudflare-pages)」を参照。
 
 ブランチ運用:
 
 - `main` push → 本番デプロイ
 - それ以外のブランチ push → プレビュー環境が自動生成される（PR ごとの URL が GitHub に自動投稿される）
 
-## ドメイン
+## ドメイン切替手順（Squarespace Domains → Cloudflare Pages）
 
-- 本番ドメイン: `amaladesigns.com`（Squarespace Domains 管理）
-- DNS 切替の具体手順は Phase 3 で本 README に追記する
+本番ドメイン `amaladesigns.com` は Squarespace Domains で管理している。
+CF Pages の `*.pages.dev` を `amaladesigns.com` / `www.amaladesigns.com` として公開するには、以下の手順で DNS を切り替える。
+
+選択肢は 2 つ:
+
+- **A. DNS レコードだけ追加する（推奨）** — 最小手順、Squarespace 側の他設定（メール等）を維持できる
+- **B. ネームサーバごと Cloudflare に移管する** — CF の DNS / WAF / Analytics をフルに使えるが、Squarespace 側の DNS は無効化される
+
+ここでは A を主路として説明する。
+
+### A. DNS レコード追加で接続する
+
+#### 1. CF Pages 側で Custom Domain を追加
+
+1. [CF ダッシュボード](https://dash.cloudflare.com/) → **Workers & Pages** → 該当プロジェクト → **Custom domains** → **Set up a custom domain**
+2. `amaladesigns.com` を入力 → **Continue**
+   - CF が apex 用の DNS レコードを提示する。典型的には **A レコード × 4 個**（CF の IPv4）、加えて **AAAA × 2 個**（IPv6）
+3. 同じ手順で `www.amaladesigns.com` も追加
+   - これは **CNAME → `<project>.pages.dev`**（例: `www-3cq.pages.dev`）として提示される
+4. 両方とも CF 側は「Verification pending」状態になる
+
+#### 2. Squarespace Domains 側に DNS レコードを追加
+
+1. [Squarespace ダッシュボード](https://account.squarespace.com/domains) → **Domains** → `amaladesigns.com` → **DNS** → **DNS Settings**
+2. **Custom Records** セクションで以下を追加（値は CF 側に表示されたものをそのまま転記する）:
+
+   | Type | Host | Data |
+   |---|---|---|
+   | `A` | `@` | `(CF が指示する IPv4 #1)` |
+   | `A` | `@` | `(CF が指示する IPv4 #2)` |
+   | `A` | `@` | `(CF が指示する IPv4 #3)` |
+   | `A` | `@` | `(CF が指示する IPv4 #4)` |
+   | `AAAA` | `@` | `(CF が指示する IPv6 #1)` |
+   | `AAAA` | `@` | `(CF が指示する IPv6 #2)` |
+   | `CNAME` | `www` | `(CF が指示する <project>.pages.dev)` |
+
+3. 既存の **A / CNAME の `@` レコード（Squarespace の Parking 等）** が残っていれば削除する
+   （同一 Host への重複は反映を阻害する）
+
+#### 3. CF 側で Verification を待つ
+
+- 数分〜十数分で「Active」表示に変わる
+- CF が Universal SSL を自動発行し、`https://amaladesigns.com` で配信開始
+
+#### 4. 疎通確認
+
+```bash
+dig amaladesigns.com +short                 # CF の IPv4 が複数返ることを確認
+dig amaladesigns.com AAAA +short            # CF の IPv6 が返ることを確認
+dig www.amaladesigns.com CNAME +short       # <project>.pages.dev が返ることを確認
+curl -I https://amaladesigns.com            # 200 OK と「server: cloudflare」を確認
+curl -I https://www.amaladesigns.com        # 同上
+```
+
+#### 5. www ↔ apex のリダイレクト
+
+- CF Pages はデフォルトで apex / www どちらでも配信される（両方とも同じ内容）
+- どちらかに正規化したい場合は、`public/_redirects` を追加して 301 を設定する。apex に統一する例:
+
+  ```
+  https://www.amaladesigns.com/* https://amaladesigns.com/:splat 301!
+  ```
+
+  または CF ダッシュボードの **Bulk Redirects / Rules** からでも設定可能。
+
+### B. ネームサーバ移管（参考）
+
+CF の DNS / WAF / Analytics をフルに使いたい場合:
+
+1. CF ダッシュボード → **Add a site** → `amaladesigns.com` を追加 → 既存 DNS を自動スキャン
+2. CF が指示する 2 つのネームサーバを控える（例: `xxx.ns.cloudflare.com`, `yyy.ns.cloudflare.com`）
+3. Squarespace Domains → `amaladesigns.com` → **Nameservers** → **Use Custom Nameservers** で CF の ns に置換
+4. 反映後（数十分〜数時間）、CF 側で DNS / Pages 連携を完了
+
+> ⚠️ ネームサーバ移管後は **Squarespace 側の DNS は無効化される**。
+> メールホスティング（MX）、他サブドメインの A/CNAME など、Squarespace で設定していたものは CF の DNS にも同等のレコードを移植する必要がある。
+
+### トラブルシューティング
+
+- **`CAA record blocks SSL issuance`**: 既存の CAA レコードが Let's Encrypt しか許可していない等。`google.com` を CAA に追加するか、CAA を一時的に削除して再試行
+- **`522` / `525` / `SSL handshake failed`**: 数分待つ。CF の SSL 発行は最大 15 分程度かかる
+- **apex が CNAME を受け付けない**: Squarespace は apex CNAME を許容しないため A レコードに切り替える。CF Pages の Custom Domain 画面でも A レコードが提示されるはず
 
 ## ライセンス
 


### PR DESCRIPTION
## Summary

`amaladesigns.com` を CF Pages に接続する **DNS 切替手順** を README に明文化（純ドキュメント PR、コード変更なし）。

2 つの選択肢を併記:

- **A. DNS レコードだけ追加（推奨）** — 最小手順、Squarespace 側のメール等の設定を維持できる
- **B. ネームサーバ移管** — CF の DNS / WAF / Analytics をフル活用できるが、Squarespace 側 DNS は無効化される

A を主路として、CF Pages 側の Custom Domain 追加、Squarespace 側の DNS Settings へのレコード追加（`A` × 4 / `AAAA` × 2 / `CNAME www`）、`dig` / `curl` での疎通確認、`www` ↔ apex のリダイレクト方針まで網羅。

## Why

Phase 3 のマイルストーンは「`amaladesigns.com` で配信開始」。コードレスな作業だが、Squarespace の UI 用語（DNS Settings の "Custom Records"）と CF Pages の用語（Custom domains）を行き来する必要があり、手順が散らかりやすい。これを 1 ヶ所に集約して、次回以降のサブドメイン追加や別ドメイン接続でも参照できるようにする。

## Test plan（マージ後にユーザーが実施）

- [x] CF Pages → 該当プロジェクト → **Custom domains** で `amaladesigns.com` / `www.amaladesigns.com` を追加
- [x] CF が提示する DNS レコード値を控える
- [x] Squarespace Domains → `amaladesigns.com` → DNS Settings に `A` × 4 / `AAAA` × 2 / `CNAME www` を追加
- [x] 既存の Parking / `@` レコードを削除
- [x] CF 側で「Active」になるのを待つ（数分〜十数分）
- [ ] `dig amaladesigns.com +short` で CF の IPv4 が返る
- [ ] `curl -I https://amaladesigns.com` で `server: cloudflare` が返る
- [x] ブラウザで https://amaladesigns.com / https://www.amaladesigns.com の両方が表示される

## 次のフェーズ

- PR #5: `feat/phase2-canvas-anim` — Canvas + simplex noise の本命アニメに差し替え

🤖 Generated with [Claude Code](https://claude.com/claude-code)